### PR TITLE
Add .NET installation guide

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,19 +1,21 @@
 # Installation & Setup
 
-Follow these steps to get the workshop files and prepare your environment. Each language track may have extra prerequisites, so check the installation guide for that track after completing these steps.
+Use these instructions to obtain the workshop files and decide how you want to work with them. Each language track may have additional prerequisites, so after setting up the repo, consult the installation guide for the track you want to follow.
 
-## Get the workshop
+## Choose your environment
 
-You can work through the material online or offline:
+### Online
 
-1. **Online through GitHub**
-   - Use the GitHub web editor or open the repository in a dev container.
-2. **Offline on your machine**
-   - Clone the repository:
-     ```bash
-     git clone https://github.com/dendrodocs/workshops.git
-     ```
-   - Or download the ZIP from [GitHub](https://github.com/dendrodocs/workshops/archive/refs/heads/main.zip) and extract it locally.
+- Open the repository in the GitHub web editor by pressing `.` on the repo page.
+- Or launch the project in a dev container such as [GitHub Codespaces](https://github.com/features/codespaces).
+
+### Offline
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/dendrodocs/workshops.git
+   ```
+2. Or download the ZIP from [GitHub](https://github.com/dendrodocs/workshops/archive/refs/heads/main.zip) and extract it locally.
 
 Git is only required for cloning or downloading the repository. The workshop exercises themselves only need the tools noted in each language track.
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,22 @@
+# Installation & Setup
+
+Follow these steps to get the workshop files and prepare your environment. Each language track may have extra prerequisites, so check the installation guide for that track after completing these steps.
+
+## Get the workshop
+
+You can work through the material online or offline:
+
+1. **Online through GitHub**
+   - Use the GitHub web editor or open the repository in a dev container.
+2. **Offline on your machine**
+   - Clone the repository:
+     ```bash
+     git clone https://github.com/dendrodocs/workshops.git
+     ```
+   - Or download the ZIP from [GitHub](https://github.com/dendrodocs/workshops/archive/refs/heads/main.zip) and extract it locally.
+
+Git is only required for cloning or downloading the repository. The workshop exercises themselves only need the tools noted in each language track.
+
+## Next steps
+
+After obtaining the workshop, open the README of the language track you want to follow. For example, the .NET track includes [additional installation steps](part1/dotnet/INSTALLATION.md) for the required SDK and IDE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Explore the world of **DendroDocs** and learn how to generate living documentati
 These workshops guide you through analyzing syntax trees in various programming languages,
 offering hands-on experience to automate documentation in a way that stays synchronized with your codebase.
 You’ll start with DendroDocs as the default tool but can adapt it to fit the needs of any project.
+See [Installation & Setup](INSTALLATION.md) to download the workshop files and prepare your environment.
 
 ## Who should follow this workshop?
 

--- a/part1/dotnet/INSTALLATION.md
+++ b/part1/dotnet/INSTALLATION.md
@@ -6,8 +6,8 @@ Before continuing, follow the [Installation & Setup](../../INSTALLATION.md) guid
 ## Prerequisites
 
 - Install the [**.NET 8 SDK**](https://dotnet.microsoft.com/download/dotnet/8.0).
-- Chapter&nbsp;1 relies on [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) because it includes the **Syntax Visualizer** and **DGML** tools.
-- The rest of the chapters work in [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) or [**Visual Studio Code**](https://code.visualstudio.com/). Other IDEs might work, but specific instructions are not provided.
+- Install [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) with the **Desktop development with C#** workload. When installing, add the **.NET Compiler Platform SDK** (which includes the Syntax Visualizer) and the **DGML editor** from the *Individual components* tab.
+- The remaining chapters work in Visual Studio 2022 or in [**Visual Studio Code**](https://code.visualstudio.com/). Other IDEs may work, but instructions are not provided.
 
 
 ## Opening the solutions

--- a/part1/dotnet/INSTALLATION.md
+++ b/part1/dotnet/INSTALLATION.md
@@ -1,0 +1,26 @@
+# Installation & Setup
+
+This workshop requires a few tools before you can start exploring the chapters. These steps will help you get ready to run the exercises and open the solutions provided for each chapter.
+Before continuing, follow the [Installation & Setup](../../INSTALLATION.md) steps at the repository root to download the workshop.
+
+## Prerequisites
+
+- Install the [**.NET 8 SDK**](https://dotnet.microsoft.com/download/dotnet/8.0).
+- Chapter&nbsp;1 relies on [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) because it includes the **Syntax Visualizer** and **DGML** tools.
+- The rest of the chapters work in [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) or [**Visual Studio Code**](https://code.visualstudio.com/). Other IDEs might work, but specific instructions are not provided.
+
+
+## Opening the solutions
+
+Each chapter has a ready-made solution in the `solutions` folder. Open the solution for the chapter you are working on:
+
+1. Navigate to `solutions/<chapter-number>`.
+2. Open the `.sln` or project folder in Visual Studio or VS Code.
+3. Follow the steps in the corresponding chapter to explore the code.
+
+## Tips
+
+- In VS Code, installing the **C# Dev Kit** and **C#** extensions from Microsoft provides a smoother experience.
+- Use Visual Studio's built-in Syntax Visualizer and DGML editors for Chapter&nbsp;1.
+
+Once your environment is set up, you're ready to dive into the chapters and start analyzing .NET projects with Roslyn.

--- a/part1/dotnet/INSTALLATION.md
+++ b/part1/dotnet/INSTALLATION.md
@@ -1,7 +1,7 @@
 # Installation & Setup
 
-This workshop requires a few tools before you can start exploring the chapters. These steps will help you get ready to run the exercises and open the solutions provided for each chapter.
-Before continuing, follow the [Installation & Setup](../../INSTALLATION.md) steps at the repository root to download the workshop.
+This workshop requires a few tools before you can start exploring the chapters.
+Before continuing, follow the [Installation & Setup](../../INSTALLATION.md) guide at the repository root to download the workshop files. Then install the prerequisites below so you can run the exercises and open the provided solutions.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ Each chapter has a ready-made solution in the `solutions` folder. Open the solut
 
 1. Navigate to `solutions/<chapter-number>`.
 2. Open the `.sln` or project folder in Visual Studio or VS Code.
-3. Follow the steps in the corresponding chapter to explore the code.
+3. Restore packages if prompted, then follow the steps in the corresponding chapter to explore the code.
 
 ## Tips
 

--- a/part1/dotnet/INSTALLATION.md
+++ b/part1/dotnet/INSTALLATION.md
@@ -6,7 +6,12 @@ Before continuing, follow the [Installation & Setup](../../INSTALLATION.md) guid
 ## Prerequisites
 
 - Install the [**.NET 8 SDK**](https://dotnet.microsoft.com/download/dotnet/8.0).
-- Install [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) with the **Desktop development with C#** workload. When installing, add the **.NET Compiler Platform SDK** (which includes the Syntax Visualizer) and the **DGML editor** from the *Individual components* tab.
+- Install [**Visual Studio 2022**](https://visualstudio.microsoft.com/vs/) with the **Desktop development with C#** workload. Visual Studio offers the best debugging and syntax tree visualization experience.
+
+### Syntax Visualizer and DGML editor
+
+When adding components to Visual Studio, make sure the **.NET Compiler Platform SDK** (which includes the Syntax Visualizer) is selected. You can find it under **Compilers, build tools, and runtimes**. Also add the **DGML editor** from the *Code tools* section on the **Individual components** tab. These tools are required for Chapter 1.
+
 - The remaining chapters work in Visual Studio 2022 or in [**Visual Studio Code**](https://code.visualstudio.com/). Other IDEs may work, but instructions are not provided.
 
 
@@ -21,6 +26,14 @@ Each chapter has a ready-made solution in the `solutions` folder. Open the solut
 ## Tips
 
 - In VS Code, installing the **C# Dev Kit** and **C#** extensions from Microsoft provides a smoother experience.
-- Use Visual Studio's built-in Syntax Visualizer and DGML editors for Chapter&nbsp;1.
+- Use Visual Studio's built-in Syntax Visualizer and DGML editors for Chapter 1.
+- To preview PlantUML diagrams, install the [PlantUML extension](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml) with:
+  ```text
+  ext install jebbs.plantuml
+  ```
+  For local rendering you can run a PlantUML server via Docker:
+  ```bash
+  docker run -d -p 8080:8080 plantuml/plantuml-server:jetty
+  ```
 
 Once your environment is set up, you're ready to dive into the chapters and start analyzing .NET projects with Roslyn.

--- a/part1/dotnet/README.md
+++ b/part1/dotnet/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the first part of the DendroDocs workshop for .NET, where you’ll get hands-on with Roslyn, officially known as the *[.NET Compiler Platform SDK](https://learn.microsoft.com/dotnet/csharp/roslyn-sdk/?wt.mc_id=AZ-MVP-5004268)*.
 
+Before you begin, see the [Installation & Setup](INSTALLATION.md) guide to configure your environment.
+
 Roslyn can help improve code quality, generate reports, and most importantly, automate documentation,
 making it invaluable for developers looking to deepen their code analysis capabilities.
 


### PR DESCRIPTION
## Summary
- add installation steps for the .NET workshop
- link new instructions from the workshop README
- put general download instructions in a repo-level doc
- include download links and use `Installation & Setup`

## Testing
- `npx cspell --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6867a5890328832d8ce8183259a735ee